### PR TITLE
Enemizer: repeat objects are replaced from the rear, because otherwis…

### DIFF
--- a/MMR.Randomizer/Enemies.cs
+++ b/MMR.Randomizer/Enemies.cs
@@ -1510,7 +1510,7 @@ namespace MMR.Randomizer
                 if (TestHardSetObject(GameObjects.Scene.RoadToSouthernSwamp, GameObjects.Actor.ChuChu, GameObjects.Actor.WarpDoor)) continue;
                 //if (TestHardSetObject(GameObjects.Scene.RoadToSouthernSwamp, GameObjects.Actor.ChuChu, GameObjects.Actor.CutsceneZelda)) continue;
                 //if (TestHardSetObject(GameObjects.Scene.SouthernSwamp, GameObjects.Actor.DragonFly, GameObjects.Actor.WarpDoor)) continue;
-                //if (TestHardSetObject(GameObjects.Scene.GoronVillage, GameObjects.Actor.Scarecrow, GameObjects.Actor.Dinofos)) continue;
+                if (TestHardSetObject(GameObjects.Scene.PiratesFortressRooms, GameObjects.Actor.Desbreko, GameObjects.Actor.UnusedPirateElevator)) continue;
                 //if (TestHardSetObject(GameObjects.Scene.Grottos, GameObjects.Actor.DekuBaba, GameObjects.Actor.WarpDoor)) continue;
                 //if (TestHardSetObject(GameObjects.Scene.AstralObservatory, GameObjects.Actor.Scarecrow, GameObjects.Actor.ClocktowerGearsAndOrgan)) continue;
                 if (TestHardSetObject(GameObjects.Scene.DekuPalace, GameObjects.Actor.Torch, GameObjects.Actor.WarpDoor)) continue;
@@ -1855,8 +1855,11 @@ namespace MMR.Randomizer
                         {
                             // just remove first one, not sure if there is an advantage of changing one over the other
                             // consideration: if the object list order changes, the scene load hickups, but so long as wel always replace first...
-                            var firstIndex = objList.FindIndex(obj => obj == uniqueObj);
-                            objList[firstIndex] = SMALLEST_OBJ;
+                            // we dont want the first we want to remove the last, as removing the first introduces more object list re-loads
+                            //var firstIndex = objList.FindIndex(obj => obj == uniqueObj);
+                            //objList[firstIndex] = SMALLEST_OBJ;
+                            var lastIndex = objList.FindLastIndex(obj => obj == uniqueObj);
+                            objList[lastIndex] = SMALLEST_OBJ;
                         }
                     }
                 }

--- a/MMR.Randomizer/GameObjects/Actor.cs
+++ b/MMR.Randomizer/GameObjects/Actor.cs
@@ -271,11 +271,26 @@ namespace MMR.Randomizer.GameObjects
         [WaterVariants(0)]  // 0 works, but OOT used FFFF
         Shabom = 0x1D,// the flying bubbles from Jabu Jabu, exist only in giants cutscenes
 
-        // this is a regular dungeon door in stonetower
         [FileID(63)]
-        [ObjectListIndex(0x1)]
+        [ObjectListIndex(0x1)] // FAKE, multi-object
+        //[ObjectListIndex(0x278)] // swamp spiderhouse
+        // multiple door objects::
+        /*  { gBossDoorDL, NULL, 130, 12, 50, 15 },
+            { gameplay_keep_DL_077990, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
+            { object_numa_obj_DL_007150, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
+            { object_hakugin_obj_DL_000128, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
+            { gGreatBayTempleObjectDoorDL, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
+            { object_ikana_obj_DL_014A40, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
+            { object_redead_obj_DL_0001A0, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
+            { object_ikninside_obj_DL_004440, object_ikninside_obj_DL_005260, 130, 0, 20, 15 },
+            { object_random_obj_DL_000190, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
+            { object_kinsta1_obj_DL_000198, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
+            { object_kaizoku_obj_DL_0001A0, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
+            { object_last_obj_DL_0039C0, gameplay_keep_DL_078A80, 130, 12, 20, 15 },
+        */
+        // also can be ikana castile door
         [SwitchFlagsPlacement(mask: 0x7F, shift: 0)]
-        IkanaCastleDoor = 0x1E, // Door_Shutter
+        DoorShutter = 0x1E, // Door_Shutter
 
         Empty1F = 0x1F,
 


### PR DESCRIPTION
…e they can be detected as different, reload, and actors that needed them to stay are culled (like doors)